### PR TITLE
ci(release): extend allowed commits to release

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -2,6 +2,14 @@ branches:
   - main
 
 plugins:
+  - - "@semantic-release/commit-analyzer"
+    - releaseRules:
+        - type: build
+          release: patch
+        - type: ci
+          release: patch
+        - type: chore
+          release: patch
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
   - - "@semantic-release/changelog"


### PR DESCRIPTION
Allow a release to be ran against commit of types:
- `chore`: patch update
- `ci`: patch update
- `build`: patch update