### PR TITLE
Refactor: move translations loading responsability from component int…

### DIFF
--- a/src/components/content/Content.tsx
+++ b/src/components/content/Content.tsx
@@ -1,17 +1,8 @@
-import {
-  Faucet,
-  Footer,
-  Header,
-  loadTranslations,
-  Typography,
-  useTheme,
-  useTranslation,
-  Logo
-} from '@okp4/ui'
+import { Faucet, Footer, Header, Typography, useTheme, useTranslation, Logo } from '@okp4/ui'
 import type { ThemeContextType, UseTranslationResponse } from '@okp4/ui'
 import lightCosmos from '@okp4/ui/lib/assets/images/cosmos-clear.png'
 import darkCosmos from '@okp4/ui/lib/assets/images/cosmos-dark.png'
-import { translationsToLoad } from '../../i18n/index'
+import '../../i18n/index'
 
 const languages = [
   {
@@ -48,7 +39,6 @@ type ContentProps = { chainId: string }
 export const Content: React.FC<ContentProps> = ({ chainId }: Readonly<ContentProps>) => {
   const { theme }: ThemeContextType = useTheme()
   const themedImage = theme === 'light' ? lightCosmos.src : darkCosmos.src
-  loadTranslations(translationsToLoad)
 
   return (
     <div className="okp4-faucet-testnet-content" style={{ backgroundImage: `url(${themedImage})` }}>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,7 +1,10 @@
+import { loadTranslations } from '@okp4/ui'
 import footer_en from './footer_en.json'
 import footer_fr from './footer_fr.json'
 
-export const translationsToLoad = [
-    { lng: 'en', namespace: 'footer', resource: footer_en },
-    { lng: 'fr', namespace: 'footer', resource: footer_fr }
-  ]
+const translationsToLoad = [
+  { lng: 'en', namespace: 'footer', resource: footer_en },
+  { lng: 'fr', namespace: 'footer', resource: footer_fr }
+]
+
+loadTranslations(translationsToLoad)


### PR DESCRIPTION
⚖️  This PR allows to move the responsibility of loading translations from the application.
Indeed, it is preferable that the component calls the translation file directly rather than loading the translations itself.