### PR TITLE
fix: change footer text color to a remaining white color

### DIFF
--- a/src/components/content/Content.tsx
+++ b/src/components/content/Content.tsx
@@ -19,9 +19,9 @@ const Okp4Link = (): JSX.Element => {
   const { t }: UseTranslationResponse = useTranslation()
 
   return (
-    <Typography as="p" color="highlighted-text" fontSize="x-small" fontWeight="xlight" noWrap>
+    <Typography as="p" color="invariant-text" fontSize="x-small" fontWeight="xlight" noWrap>
       {`${t('footer:brand-link')} `}
-      <Typography color="highlighted-text" fontSize="x-small" fontWeight="bold">
+      <Typography color="invariant-text" fontSize="x-small" fontWeight="bold">
         <a
           className="okp4-brand-link"
           href="https://okp4.network/"


### PR DESCRIPTION
Since we changed the colors of the theme, the color of the footer text was no longer readable, it had to be changed so that it remains white regardless of the theme.

Before: 
![Capture d’écran 2022-09-15 à 12 33 14](https://user-images.githubusercontent.com/35332974/190382982-b4c255f9-fe52-42a0-a500-627887f14448.png)

After:
![Capture d’écran 2022-09-15 à 12 33 44](https://user-images.githubusercontent.com/35332974/190382977-59ac666a-a0ed-4113-b2c2-1c14d2375893.png)

