### PR TITLE
build(deps): bump nodejs version to 16.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node environment (for building)
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 16.18
 
       - name: Fetch dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Setup node environment (for building)
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 16.18
 
       - name: Fetch dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #-------------
-FROM node:16-alpine AS deps
+FROM node:16.18-alpine AS deps
 
 RUN apk add --no-cache libc6-compat=1.2.3-r0
 
@@ -10,7 +10,7 @@ COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
 #-------------
-FROM node:16-alpine AS builder
+FROM node:16.18-alpine AS builder
 
 WORKDIR /app
 
@@ -22,7 +22,7 @@ ENV NEXT_TELEMETRY_DISABLED 1
 RUN yarn build
 
 #-------------
-FROM node:16-alpine AS runner
+FROM node:16.18-alpine AS runner
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "web": "https://okp4.network"
   },
   "engines": {
-    "node": "^16.14.0",
+    "node": "^16.18.0",
     "yarn": "~1.22.17"
   },
   "scripts": {


### PR DESCRIPTION
Align Node version to [Node v16.18.x](https://nodejs.org/en/blog/release/v16.18.0/) LTS, similar to what is done on project [okp4/portal-web](https://github.com/okp4/portal-web/pull/73).